### PR TITLE
caution against estimation in custom transformations

### DIFF
--- a/R/adjust-predictions-custom.R
+++ b/R/adjust-predictions-custom.R
@@ -8,6 +8,14 @@
 #' the commands.
 #' @param ... Name-value pairs of expressions. See [dplyr::mutate()].
 #'
+#' @section Data-dependent transformations:
+#' Note that custom adjustments should not carry out estimation. If they do,
+#' the estimation steps will be carried out independently at `fit()`
+#' and `predict()` time. For example, if your transformation includes a mean
+#' shift, the postprocessor will take the mean of the column supplied in the
+#' training data at `fit()` and, rather than reusing that mean at `predict()`
+#' will take the mean again of the dataset supplied at `predict()` time.
+#'
 #' @inheritSection adjust_equivocal_zone Data Usage
 #'
 #' @examplesIf rlang::is_installed(c("probably", "modeldata"))
@@ -42,8 +50,6 @@ adjust_predictions_custom <- function(x, ..., .pkgs = character(0)) {
       arguments = list(commands = cmds, pkgs = .pkgs),
       results = list(),
       trained = FALSE,
-      # todo: should there be a user interface to tell tailor whether this
-      # adjustment requires fit?
       requires_fit = FALSE
     )
 

--- a/man/adjust_predictions_custom.Rd
+++ b/man/adjust_predictions_custom.Rd
@@ -18,6 +18,16 @@ the commands.}
 This adjustment functions allows for arbitrary transformations of model
 predictions using \code{\link[dplyr:mutate]{dplyr::mutate()}} statements.
 }
+\section{Data-dependent transformations}{
+
+Note that custom adjustments should not carry out estimation. If they do,
+the estimation steps will be carried out independently at \code{fit()}
+and \code{predict()} time. For example, if your transformation includes a mean
+shift, the postprocessor will take the mean of the column supplied in the
+training data at \code{fit()} and, rather than reusing that mean at \code{predict()}
+will take the mean again of the dataset supplied at \code{predict()} time.
+}
+
 \section{Data Usage}{
 
 This adjustment doesn't require estimation and, as such, the same data that's


### PR DESCRIPTION
Closes #62.

Based on your reply, @topepo, I also considered a "blocklist" of function calls for things like `mean()` or `lm()`; if one of those functions is called in the expression, we could warn with the same cautionary note. At the same time, this seems incomplete by design (we can only come up with so many examples) and a bit cumbersome to maintain. Requesting your review just to hear your thoughts on whether this approach of just cautioning against estimation via documentation is enough or whether we should do something more drastic.