### PR TITLE
unify printing of trained tag

### DIFF
--- a/R/adjust-equivocal-zone.R
+++ b/R/adjust-equivocal-zone.R
@@ -97,7 +97,7 @@ print.equivocal_zone <- function(x, ...) {
     trn <- ifelse(x$trained, " [trained]", "")
     cli::cli_bullets(c(
       "*" = "Add equivocal zone of size
-             {signif(x$arguments$value, digits = 3)}.{trn}"
+             {signif(x$arguments$value, digits = 3)}. {trn}"
     ))
   }
   invisible(x)

--- a/R/adjust-numeric-range.R
+++ b/R/adjust-numeric-range.R
@@ -76,7 +76,7 @@ print.numeric_range <- function(x, ...) {
   rng_txt <- paste0("between [", lower_limit, ", ", upper_limit, "]")
 
   cli::cli_bullets(c(
-    "*" = "Constrain numeric predictions to be {rng_txt}{trn}."
+    "*" = "Constrain numeric predictions to be {rng_txt}. {trn}"
   ))
   invisible(x)
 }

--- a/R/adjust-predictions-custom.R
+++ b/R/adjust-predictions-custom.R
@@ -65,7 +65,7 @@ adjust_predictions_custom <- function(x, ..., .pkgs = character(0)) {
 #' @export
 print.predictions_custom <- function(x, ...) {
   trn <- ifelse(x$trained, " [trained]", "")
-  cli::cli_bullets(c("*" = "Adjust predictions using custom code.{trn}"))
+  cli::cli_bullets(c("*" = "Adjust predictions using custom code. {trn}"))
   invisible(x)
 }
 

--- a/R/adjust-probability-threshold.R
+++ b/R/adjust-probability-threshold.R
@@ -77,7 +77,7 @@ print.probability_threshold <- function(x, ...) {
     trn <- ifelse(x$trained, " [trained]", "")
     cli::cli_bullets(c(
       "*" = "Adjust probability threshold to \\
-             {signif(x$arguments$threshold, digits = 3)}.{trn}"
+             {signif(x$arguments$threshold, digits = 3)}. {trn}"
     ))
   }
   invisible(x)


### PR DESCRIPTION
I noticed that the location of the `[trained]` was quite different. This should unify it again