### PR TITLE
handling no calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     tidyselect,
     vctrs
 Suggests: 
+    betacal,
     dials,
     mgcv,
     modeldata,

--- a/R/adjust-numeric-calibration.R
+++ b/R/adjust-numeric-calibration.R
@@ -7,11 +7,12 @@
 #' range of outputs.
 #'
 #' @param x A [tailor()].
-#' @param method Character. One of `"linear"`, `"isotonic"`, or
-#' `"isotonic_boot"`, corresponding to the function from the \pkg{probably}
+#' @param method Character. One of `"linear"`, `"isotonic"`,`"isotonic_boot"`,
+#' or `"none"`, corresponding to the function from the \pkg{probably}
 #' package `probably::cal_estimate_linear()`,
-#' `probably::cal_estimate_isotonic()`, or
-#' `probably::cal_estimate_isotonic_boot()`, respectively.
+#' `probably::cal_estimate_isotonic()`
+#' `probably::cal_estimate_isotonic_boot()`, or
+#' `probably::cal_estimate_none()`, respectively.
 #'
 #' @section Data Usage:
 #' This adjustment requires estimation and, as such, different subsets of data
@@ -21,6 +22,8 @@
 #' situated in a workflow, tailors will automatically be estimated with
 #' appropriate subsets of data.
 #'
+#' Note that, when calling [fit.tailor()], if the calibration data have zero or
+#' one row, the `method` is changed to `"none"`.
 #' @examplesIf rlang::is_installed("probably")
 #' library(tibble)
 #'
@@ -49,11 +52,11 @@ adjust_numeric_calibration <- function(x, method = NULL) {
   validate_probably_available()
 
   check_tailor(x, calibration_type = "numeric")
-  # wait to `check_method()` until `fit()` time
+  # wait to `check_cal_method()` until `fit()` time
   if (!is.null(method) & !is_tune(method)) {
     arg_match0(
       method,
-      c("linear", "isotonic", "isotonic_boot")
+      c("linear", "isotonic", "isotonic_boot", "none")
     )
   }
 
@@ -102,7 +105,11 @@ print.numeric_calibration <- function(x, ...) {
 fit.numeric_calibration <- function(object, data, tailor = NULL, ...) {
   validate_probably_available()
 
-  method <- check_method(object$arguments$method, tailor$type)
+  method <- check_cal_method(
+    object$arguments$method,
+    type = tailor$type,
+    cal_data = data
+  )
   # todo: adjust_numeric_calibration() should take arguments to pass to
   # cal_estimate_* via dots
   fit <-

--- a/R/adjust-probability-calibration.R
+++ b/R/adjust-probability-calibration.R
@@ -9,7 +9,7 @@
 #'
 #' @param x A [tailor()].
 #' @param method Character. One of `"logistic"`, `"multinomial"`,
-#' `"beta"`, `"isotonic"`, or `"isotonic_boot"`, corresponding to the
+#' `"beta"`, `"isotonic"`, `"isotonic_boot"`, or `"none"`, corresponding to the
 #' function from the \pkg{probably} package `probably::cal_estimate_logistic()`,
 #' `probably::cal_estimate_multinomial()`, etc., respectively.
 #'
@@ -52,11 +52,11 @@ adjust_probability_calibration <- function(x, method = NULL) {
   validate_probably_available()
 
   check_tailor(x, calibration_type = "probability")
-  # wait to `check_method()` until `fit()` time
+  # wait to `check_cal_method()` until `fit()` time
   if (!is.null(method) & !is_tune(method)) {
     arg_match(
       method,
-      c("logistic", "multinomial", "beta", "isotonic", "isotonic_boot")
+      c("logistic", "multinomial", "beta", "isotonic", "isotonic_boot", "none")
     )
   }
 
@@ -105,7 +105,11 @@ print.probability_calibration <- function(x, ...) {
 fit.probability_calibration <- function(object, data, tailor = NULL, ...) {
   validate_probably_available()
 
-  method <- check_method(object$arguments$method, tailor$type)
+  method <- check_cal_method(
+    object$arguments$method,
+    type = tailor$type,
+    cal_data = data
+  )
   # todo: adjust_probability_calibration() should take arguments to pass to
   # cal_estimate_* via dots
   fit <-

--- a/R/tailor.R
+++ b/R/tailor.R
@@ -164,6 +164,8 @@ print.tailor <- function(x, ...) {
 #' on how tidymodels makes that split; when situated in a model workflow,
 #' tailors will automatically be trained on the appropriate subset of data.
 #'
+#' Note that if `.data` has zero or one row, the `method` is changed to `"none"`.
+#'
 #' @param object A [tailor()].
 #' @param .data,new_data A data frame containing predictions from a model.
 #' @param outcome <[`tidy-select`][dplyr::dplyr_tidy_select]> Only required

--- a/R/tailor.R
+++ b/R/tailor.R
@@ -202,6 +202,9 @@ fit.tailor <- function(
   columns$probabilities <- names(
     tidyselect::eval_select(enquo(probabilities), .data)
   )
+  # For type = "binary", update based on number of probability estimates
+  object$type <- update_type(object$type, columns$probabilities)
+
   if (
     "probability" %in%
       purrr::map_chr(object$adjustments, purrr::pluck, "inputs")

--- a/R/utils.R
+++ b/R/utils.R
@@ -333,9 +333,9 @@ check_calibration_type <- function(
   }
 }
 
-types_regression <- c("linear", "isotonic", "isotonic_boot")
-types_binary <- c("logistic", "beta", "isotonic", "isotonic_boot")
-types_multiclass <- c("multinomial", "beta", "isotonic", "isotonic_boot")
+types_regression <- c("linear", "isotonic", "isotonic_boot", "none")
+types_binary <- c("logistic", "beta", "isotonic", "isotonic_boot", "none")
+types_multiclass <- c("multinomial", "beta", "isotonic", "isotonic_boot", "none")
 # a check function to be called when a tailor is being `fit()`ted.
 # by the time a tailor is fitted, we have:
 # * `method`, the `method` argument passed to an `adjust_*` function
@@ -343,9 +343,10 @@ types_multiclass <- c("multinomial", "beta", "isotonic", "isotonic_boot")
 #       `adjust_*()` function via `arg_match0()`.
 # * `tailor_type`, the `type` argument either specified in `tailor()`
 #   or inferred in `fit.tailor()`.
-check_method <- function(
+check_cal_method <- function(
   method,
   type,
+  cal_data,
   arg = caller_arg(method),
   call = caller_env()
 ) {
@@ -355,6 +356,15 @@ check_method <- function(
                    {.fn fit} time.",
       call = call
     )
+  }
+
+  if (nrow(cal_data) < 2) {
+    cli::cli_inform(
+      "The calibration data has {nrow(cal_data)} row{?s}. There is not enough
+      data for calibration so {.arg method} is changed from {.val {method}}
+      to {.val none}."
+    )
+    method <- "none"
   }
 
   # if no `method` was supplied, infer a reasonable one based on the `type`

--- a/R/validation-rules.R
+++ b/R/validation-rules.R
@@ -114,6 +114,9 @@ infer_type <- function(orderings) {
     return("regression")
   }
 
+  # Note: default for classification is "binary"; this can be updated once
+  # the data are seen. If there are 3+ classes, the type is changed to
+  # "multiclass"
   if (
     all(orderings$output_prob | orderings$output_class | orderings$output_all)
   ) {
@@ -121,4 +124,13 @@ infer_type <- function(orderings) {
   }
 
   "unknown"
+}
+
+update_type <- function(type, probabilities) {
+  if (type  == "binary") {
+    if (length(probabilities) > 2) {
+      type <- "multiclass"
+    }
+  }
+  type
 }

--- a/man/adjust_numeric_calibration.Rd
+++ b/man/adjust_numeric_calibration.Rd
@@ -9,11 +9,12 @@ adjust_numeric_calibration(x, method = NULL)
 \arguments{
 \item{x}{A \code{\link[=tailor]{tailor()}}.}
 
-\item{method}{Character. One of \code{"linear"}, \code{"isotonic"}, or
-\code{"isotonic_boot"}, corresponding to the function from the \pkg{probably}
+\item{method}{Character. One of \code{"linear"}, \code{"isotonic"},\code{"isotonic_boot"},
+or \code{"none"}, corresponding to the function from the \pkg{probably}
 package \code{probably::cal_estimate_linear()},
-\code{probably::cal_estimate_isotonic()}, or
-\code{probably::cal_estimate_isotonic_boot()}, respectively.}
+\code{probably::cal_estimate_isotonic()}
+\code{probably::cal_estimate_isotonic_boot()}, or
+\code{probably::cal_estimate_none()}, respectively.}
 }
 \description{
 Calibration for regression models involves adjusting the model's
@@ -29,6 +30,9 @@ by the same name in \code{?workflows::add_tailor()} for more information on
 preventing data leakage with postprocessors that require estimation. When
 situated in a workflow, tailors will automatically be estimated with
 appropriate subsets of data.
+
+Note that, when calling \code{\link[=fit.tailor]{fit.tailor()}}, if the calibration data have zero or
+one row, the \code{method} is changed to \code{"none"}.
 }
 
 \examples{

--- a/man/adjust_probability_calibration.Rd
+++ b/man/adjust_probability_calibration.Rd
@@ -10,7 +10,7 @@ adjust_probability_calibration(x, method = NULL)
 \item{x}{A \code{\link[=tailor]{tailor()}}.}
 
 \item{method}{Character. One of \code{"logistic"}, \code{"multinomial"},
-\code{"beta"}, \code{"isotonic"}, or \code{"isotonic_boot"}, corresponding to the
+\code{"beta"}, \code{"isotonic"}, \code{"isotonic_boot"}, or \code{"none"}, corresponding to the
 function from the \pkg{probably} package \code{probably::cal_estimate_logistic()},
 \code{probably::cal_estimate_multinomial()}, etc., respectively.}
 }
@@ -29,6 +29,9 @@ by the same name in \code{?workflows::add_tailor()} for more information on
 preventing data leakage with postprocessors that require estimation. When
 situated in a workflow, tailors will automatically be estimated with
 appropriate subsets of data.
+
+Note that, when calling \code{\link[=fit.tailor]{fit.tailor()}}, if the calibration data have zero or
+one row, the \code{method} is changed to \code{"none"}.
 }
 
 \examples{

--- a/man/fit.tailor.Rd
+++ b/man/fit.tailor.Rd
@@ -49,5 +49,7 @@ for training the tailor and evaluating its performance on predictions.
 See the Data Usage section in \code{?workflows::add_tailor()} for more information
 on how tidymodels makes that split; when situated in a model workflow,
 tailors will automatically be trained on the appropriate subset of data.
+
+Note that if \code{.data} has zero or one row, the \code{method} is changed to \code{"none"}.
 }
 

--- a/tests/testthat/_snaps/adjust-numeric-calibration.md
+++ b/tests/testthat/_snaps/adjust-numeric-calibration.md
@@ -48,7 +48,7 @@
       adjust_numeric_calibration(tailor(), "boop")
     Condition
       Error in `adjust_numeric_calibration()`:
-      ! `method` must be one of "linear", "isotonic", or "isotonic_boot", not "boop".
+      ! `method` must be one of "linear", "isotonic", "isotonic_boot", or "none", not "boop".
 
 ---
 
@@ -56,14 +56,38 @@
       adjust_numeric_calibration(tailor(), "binary")
     Condition
       Error in `adjust_numeric_calibration()`:
-      ! `method` must be one of "linear", "isotonic", or "isotonic_boot", not "binary".
+      ! `method` must be one of "linear", "isotonic", "isotonic_boot", or "none", not "binary".
       i Did you mean "linear"?
 
 # tuning the calibration method
 
     Code
-      fit(tlr, d_calibration, outcome = y, estimate = y_pred)
+      fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
     Condition
       Error in `fit()`:
       ! The calibration method cannot be a value of `tune()` at `fit()` time.
+
+# too few data
+
+    Code
+      fit(tlr, d_reg_calibration[0, ], outcome = y, estimate = y_pred)
+    Message
+      The calibration data has 0 rows. There is not enough data for calibration so `method` is changed from "linear" to "none".
+      
+      -- tailor ----------------------------------------------------------------------
+      A regression postprocessor with 1 adjustment:
+      
+      * Re-calibrate numeric predictions using linear method. [trained]
+
+---
+
+    Code
+      fit(tlr, d_reg_calibration[1, ], outcome = y, estimate = y_pred)
+    Message
+      The calibration data has 1 row. There is not enough data for calibration so `method` is changed from "linear" to "none".
+      
+      -- tailor ----------------------------------------------------------------------
+      A regression postprocessor with 1 adjustment:
+      
+      * Re-calibrate numeric predictions using linear method. [trained]
 

--- a/tests/testthat/_snaps/adjust-probability-calibration.md
+++ b/tests/testthat/_snaps/adjust-probability-calibration.md
@@ -34,8 +34,8 @@
 ---
 
     Code
-      fit(adjust_probability_calibration(tailor()), two_class_example, outcome = c(
-        truth), estimate = c(predicted), probabilities = c(Class1, Class2))
+      fit(adjust_probability_calibration(tailor()), d_bin_calibration, outcome = c(y),
+      estimate = c(predicted), probabilities = c(a, b))
     Message
       
       -- tailor ----------------------------------------------------------------------
@@ -49,7 +49,7 @@
       adjust_probability_calibration(tailor(), "boop")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `method` must be one of "logistic", "multinomial", "beta", "isotonic", or "isotonic_boot", not "boop".
+      ! `method` must be one of "logistic", "multinomial", "beta", "isotonic", "isotonic_boot", or "none", not "boop".
 
 ---
 
@@ -57,14 +57,30 @@
       adjust_probability_calibration(tailor(), "linear")
     Condition
       Error in `adjust_probability_calibration()`:
-      ! `method` must be one of "logistic", "multinomial", "beta", "isotonic", or "isotonic_boot", not "linear".
+      ! `method` must be one of "logistic", "multinomial", "beta", "isotonic", "isotonic_boot", or "none", not "linear".
 
 # tuning the calibration method
 
     Code
-      fit(tlr, d_calibration, outcome = c(truth), estimate = c(predicted),
-      probabilities = c(Class1, Class2))
+      fit(tlr, d_bin_calibration, outcome = c(y), estimate = c(predicted),
+      probabilities = c(a, b))
     Condition
       Error in `fit()`:
       ! The calibration method cannot be a value of `tune()` at `fit()` time.
+
+# too few data
+
+    Code
+      tlr_fit <- fit(tlr, d_bin_calibration[0, ], outcome = c(y), estimate = c(
+        predicted), probabilities = c(a, b))
+    Message
+      The calibration data has 0 rows. There is not enough data for calibration so `method` is changed from "logistic" to "none".
+
+---
+
+    Code
+      tlr_fit <- fit(tlr, d_bin_calibration[1, ], outcome = c(y), estimate = c(
+        predicted), probabilities = c(a, b))
+    Message
+      The calibration data has 1 row. There is not enough data for calibration so `method` is changed from "logistic" to "none".
 

--- a/tests/testthat/helper-calibration.R
+++ b/tests/testthat/helper-calibration.R
@@ -1,0 +1,36 @@
+library(dplyr)
+
+set.seed(1)
+d_reg_calibration <- dplyr::tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
+d_reg_test <- dplyr::tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
+
+# ------------------------------------------------------------------------------
+
+set.seed(1)
+d_bin_calibration <-
+  dplyr::tibble(y = factor(rep(letters[1:2], each = 50)), a = runif(100)) |>
+  dplyr::mutate(b = 1 - a)
+d_bin_test <-
+  dplyr::tibble(y = factor(rep(letters[1:2], each = 50)), a = runif(100)) |>
+  dplyr::mutate(b = 1 - a)
+
+# ------------------------------------------------------------------------------
+
+set.seed(1)
+probs <- matrix(runif(2 * 3 * 3 * 50), ncol = 3)
+probs <- apply(probs, 1, function(x) x/sum(x))
+
+d_mlt_calibration <-
+  dplyr::tibble(
+    y = factor(rep(letters[1:3], each = 50)),
+    a = probs[1, 1:150],
+    b = probs[2, 1:150],
+    c = probs[3, 1:150]
+  )
+d_mlttest <-
+  dplyr::tibble(
+    y = factor(rep(letters[1:3], each = 50)),
+    a = probs[1, 151:300],
+    b = probs[2, 151:300],
+    c = probs[3, 151:300]
+  )

--- a/tests/testthat/helper-calibration.R
+++ b/tests/testthat/helper-calibration.R
@@ -9,10 +9,10 @@ d_reg_test <- dplyr::tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
 set.seed(1)
 d_bin_calibration <-
   dplyr::tibble(y = factor(rep(letters[1:2], each = 50)), a = runif(100)) |>
-  dplyr::mutate(b = 1 - a)
+  dplyr::mutate(b = 1 - a, predicted = sample(y))
 d_bin_test <-
   dplyr::tibble(y = factor(rep(letters[1:2], each = 50)), a = runif(100)) |>
-  dplyr::mutate(b = 1 - a)
+  dplyr::mutate(b = 1 - a, predicted = sample(y))
 
 # ------------------------------------------------------------------------------
 
@@ -26,11 +26,13 @@ d_mlt_calibration <-
     a = probs[1, 1:150],
     b = probs[2, 1:150],
     c = probs[3, 1:150]
-  )
-d_mlttest <-
+  ) |>
+  dplyr::mutate(predicted = sample(y))
+d_mlt_test <-
   dplyr::tibble(
     y = factor(rep(letters[1:3], each = 50)),
     a = probs[1, 151:300],
     b = probs[2, 151:300],
     c = probs[3, 151:300]
-  )
+  ) |>
+  dplyr::mutate(predicted = sample(y))

--- a/tests/testthat/test-adjust-numeric-calibration.R
+++ b/tests/testthat/test-adjust-numeric-calibration.R
@@ -29,7 +29,6 @@ test_that("basic adjust_numeric_calibration usage works", {
 
 test_that("linear adjust_numeric_calibration usage works", {
   skip_if_not_installed("mgcv")
-  skip_if_not_installed("probably")
 
   tlr <-
     tailor() |>
@@ -46,8 +45,6 @@ test_that("linear adjust_numeric_calibration usage works", {
 })
 
 test_that("isotonic adjust_numeric_calibration usage works", {
-  skip_if_not_installed("probably")
-
    tlr <-
     tailor() |>
     adjust_numeric_calibration(method = "isotonic")
@@ -64,7 +61,6 @@ test_that("isotonic adjust_numeric_calibration usage works", {
 
 
 test_that("isotonic boot adjust_numeric_calibration usage works", {
-  skip_if_not_installed("probably")
 
   tlr <-
     tailor() |>
@@ -82,7 +78,6 @@ test_that("isotonic boot adjust_numeric_calibration usage works", {
 })
 
 test_that("no adjust_numeric_calibration usage works", {
-  skip_if_not_installed("probably")
 
   tlr <-
     tailor() |>

--- a/tests/testthat/test-adjust-numeric-calibration.R
+++ b/tests/testthat/test-adjust-numeric-calibration.R
@@ -3,12 +3,6 @@ skip_if_not_installed("probably")
 test_that("basic adjust_numeric_calibration usage works", {
   skip_if_not_installed("mgcv")
 
-  library(tibble)
-
-  set.seed(1)
-  d_calibration <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
-  d_test <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
-
   # fitting and predicting happens without raising conditions
   expect_no_condition(
     tlr <-
@@ -17,11 +11,11 @@ test_that("basic adjust_numeric_calibration usage works", {
   )
 
   expect_no_warning(
-    tlr_fit <- fit(tlr, d_calibration, outcome = y, estimate = y_pred)
+    tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
   )
 
   expect_no_condition(
-    tlr_pred <- predict(tlr_fit, d_test)
+    tlr_pred <- predict(tlr_fit, d_reg_test)
   )
 
   # classes are as expected
@@ -30,18 +24,82 @@ test_that("basic adjust_numeric_calibration usage works", {
   expect_s3_class(tlr_pred, "tbl_df")
 
   # column names are as expected
-  expect_equal(colnames(d_test), colnames(tlr_pred))
+  expect_equal(colnames(d_reg_test), colnames(tlr_pred))
+})
 
-  # calculations match those done manually
-  # TODO: write out the probably code manually here
+test_that("linear adjust_numeric_calibration usage works", {
+  skip_if_not_installed("mgcv")
+  skip_if_not_installed("probably")
+
+  tlr <-
+    tailor() |>
+    adjust_numeric_calibration(method = "linear")
+
+  tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
+  tlr_pred <- predict(tlr_fit, d_reg_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_linear_spline", "cal_regression", "cal_object")
+  )
+  expect_true(all(d_reg_test$y_pred != tlr_pred$y_pred))
+})
+
+test_that("isotonic adjust_numeric_calibration usage works", {
+  skip_if_not_installed("probably")
+
+   tlr <-
+    tailor() |>
+    adjust_numeric_calibration(method = "isotonic")
+
+  tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
+  tlr_pred <- predict(tlr_fit, d_reg_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic", "cal_regression", "cal_object")
+  )
+  expect_true(all(d_reg_test$y_pred != tlr_pred$y_pred))
+})
+
+
+test_that("isotonic boot adjust_numeric_calibration usage works", {
+  skip_if_not_installed("probably")
+
+  tlr <-
+    tailor() |>
+    adjust_numeric_calibration(method = "isotonic_boot")
+
+  set.seed(1)
+  tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
+  tlr_pred <- predict(tlr_fit, d_reg_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic_boot", "cal_regression", "cal_object")
+  )
+  expect_true(all(d_reg_test$y_pred != tlr_pred$y_pred))
+})
+
+test_that("no adjust_numeric_calibration usage works", {
+  skip_if_not_installed("probably")
+
+  tlr <-
+    tailor() |>
+    adjust_numeric_calibration(method = "none")
+
+  set.seed(1)
+  tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
+  tlr_pred <- predict(tlr_fit, d_reg_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_none", "cal_regression", "cal_object")
+  )
+  expect_true(all(d_reg_test$y_pred == tlr_pred$y_pred))
 })
 
 test_that("adjust_numeric_calibration() respects `method` argument", {
-  library(tibble)
-
-  set.seed(1)
-  d_calibration <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
-  d_test <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
 
   expect_no_condition(
     tlr <-
@@ -50,11 +108,11 @@ test_that("adjust_numeric_calibration() respects `method` argument", {
   )
 
   expect_no_condition(
-    tlr_fit <- fit(tlr, d_calibration, outcome = y, estimate = y_pred)
+    tlr_fit <- fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred)
   )
 
   expect_no_condition(
-    tlr_pred <- predict(tlr_fit, d_test)
+    tlr_pred <- predict(tlr_fit, d_reg_test)
   )
 
   # classes are as expected
@@ -63,7 +121,7 @@ test_that("adjust_numeric_calibration() respects `method` argument", {
   expect_s3_class(tlr_pred, "tbl_df")
 
   # column names are as expected
-  expect_equal(colnames(d_test), colnames(tlr_pred))
+  expect_equal(colnames(d_reg_test), colnames(tlr_pred))
 
   # probably actually used an isotonic calibrator
   expect_equal(
@@ -121,11 +179,6 @@ test_that("tunable S3 method", {
 
 
 test_that("tuning the calibration method", {
-  library(tibble)
-
-  set.seed(1)
-  d_calibration <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
-  d_test <- tibble(y = rnorm(100), y_pred = y / 2 + rnorm(100))
 
   tlr <-
     tailor() |>
@@ -133,7 +186,21 @@ test_that("tuning the calibration method", {
   expect_true(tailor:::is_tune(tlr$adjustments[[1]]$arguments$method))
 
   expect_snapshot(
-    fit(tlr, d_calibration, outcome = y, estimate = y_pred),
+    fit(tlr, d_reg_calibration, outcome = y, estimate = y_pred),
     error = TRUE
   )
+})
+
+test_that("too few data", {
+  tlr <-
+    tailor() |>
+    adjust_numeric_calibration(method = "linear")
+
+  expect_snapshot(
+    fit(tlr, d_reg_calibration[0,], outcome = y, estimate = y_pred)
+  )
+  expect_snapshot(
+    fit(tlr, d_reg_calibration[1,], outcome = y, estimate = y_pred)
+  )
+
 })

--- a/tests/testthat/test-adjust-probability-calibration.R
+++ b/tests/testthat/test-adjust-probability-calibration.R
@@ -1,16 +1,7 @@
 skip_if_not_installed("probably")
 
 test_that("basic adjust_probability_calibration() usage works", {
-  skip_if_not_installed("modeldata")
   skip_if_not_installed("mgcv")
-
-  library(modeldata)
-
-  # split example data
-  set.seed(1)
-  in_rows <- sample(c(TRUE, FALSE), nrow(two_class_example), replace = TRUE)
-  d_calibration <- two_class_example[in_rows, ]
-  d_test <- two_class_example[!in_rows, ]
 
   # fitting and predicting happens without raising conditions
   expect_no_condition(
@@ -19,18 +10,20 @@ test_that("basic adjust_probability_calibration() usage works", {
       adjust_probability_calibration(method = "logistic")
   )
 
-  expect_no_condition(
+  # The first time executed, there may be a message "Registered S3 method
+  # overwritten by 'butcher':"
+  expect_no_warning(
     tlr_fit <- fit(
       tlr,
-      d_calibration,
-      outcome = c(truth),
+      d_bin_calibration,
+      outcome = c(y),
       estimate = c(predicted),
-      probabilities = c(Class1, Class2)
+      probabilities = c(a, b)
     )
   )
 
   expect_no_condition(
-    tlr_pred <- predict(tlr_fit, d_test)
+    tlr_pred <- predict(tlr_fit, d_bin_test)
   )
 
   # classes are as expected
@@ -39,22 +32,10 @@ test_that("basic adjust_probability_calibration() usage works", {
   expect_s3_class(tlr_pred, "tbl_df")
 
   # column names are as expected
-  expect_equal(colnames(d_test), colnames(tlr_pred))
-
-  # calculations match those done manually
-  # TODO: write out the manual code with probably
+  expect_equal(colnames(d_bin_test), colnames(tlr_pred))
 })
 
 test_that("basic adjust_probability_calibration() usage works", {
-  skip_if_not_installed("modeldata")
-  library(modeldata)
-
-  # split example data
-  set.seed(1)
-  in_rows <- sample(c(TRUE, FALSE), nrow(two_class_example), replace = TRUE)
-  d_calibration <- two_class_example[in_rows, ]
-  d_test <- two_class_example[!in_rows, ]
-
   # fitting and predicting happens without raising conditions
   expect_no_condition(
     tlr <-
@@ -65,15 +46,15 @@ test_that("basic adjust_probability_calibration() usage works", {
   expect_no_condition(
     tlr_fit <- fit(
       tlr,
-      d_calibration,
-      outcome = c(truth),
+      d_bin_calibration,
+      outcome = c(y),
       estimate = c(predicted),
-      probabilities = c(Class1, Class2)
+      probabilities = c(a, b)
     )
   )
 
   expect_no_condition(
-    tlr_pred <- predict(tlr_fit, d_test)
+    tlr_pred <- predict(tlr_fit, d_bin_test)
   )
 
   # classes are as expected
@@ -82,13 +63,256 @@ test_that("basic adjust_probability_calibration() usage works", {
   expect_s3_class(tlr_pred, "tbl_df")
 
   # column names are as expected
-  expect_equal(colnames(d_test), colnames(tlr_pred))
+  expect_equal(colnames(d_bin_test), colnames(tlr_pred))
 
   # probably actually used an isotonic calibrator
   expect_equal(
     tlr_fit$adjustments[[1]]$results$fit$method,
     "Isotonic regression calibration"
   )
+})
+
+test_that("logistic adjust_probability_calibration usage works", {
+  skip_if_not_installed("mgcv")
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "logistic")
+
+  tlr_fit <- fit(
+    tlr,
+    d_bin_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b)
+  )
+  tlr_pred <- predict(tlr_fit, d_bin_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_logistic_spline", "cal_binary", "cal_object")
+  )
+  expect_true(all(d_bin_test$a != tlr_pred$a))
+  expect_true(all(d_bin_test$b != tlr_pred$b))
+})
+
+test_that("binary isotonic adjust_probability_calibration usage works", {
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "isotonic")
+
+  tlr_fit <- fit(
+    tlr,
+    d_bin_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b)
+  )
+  tlr_pred <- predict(tlr_fit, d_bin_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic", "cal_binary", "cal_object")
+  )
+  expect_true(all(d_bin_test$a != tlr_pred$a))
+  expect_true(all(d_bin_test$b != tlr_pred$b))
+})
+
+test_that("binary isotonic boot adjust_probability_calibration usage works", {
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "isotonic_boot")
+
+  set.seed(1)
+  tlr_fit <- fit(
+    tlr,
+    d_bin_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b)
+  )
+  tlr_pred <- predict(tlr_fit, d_bin_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic_boot", "cal_binary", "cal_object")
+  )
+  expect_true(all(d_bin_test$a != tlr_pred$a))
+  expect_true(all(d_bin_test$b != tlr_pred$b))
+})
+
+test_that("binary beta adjust_probability_calibration usage works", {
+  skip_if_not_installed("betacal")
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "beta")
+
+  set.seed(1)
+  tlr_fit <- fit(
+    tlr,
+    d_bin_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b)
+  )
+  tlr_pred <- predict(tlr_fit, d_bin_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_beta", "cal_binary", "cal_object")
+  )
+  expect_true(all(d_bin_test$a != tlr_pred$a))
+  expect_true(all(d_bin_test$b != tlr_pred$b))
+})
+
+test_that("binary no adjust_probability_calibration usage works", {
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "none")
+
+  tlr_fit <- fit(
+    tlr,
+    d_bin_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b)
+  )
+  tlr_pred <- predict(tlr_fit, d_bin_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_none", "cal_binary", "cal_object")
+  )
+  expect_true(all(d_bin_test$a == tlr_pred$a))
+  expect_true(all(d_bin_test$b == tlr_pred$b))
+})
+
+
+test_that("multinomial adjust_probability_calibration usage works", {
+  skip_if_not_installed("mgcv")
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "multinomial")
+
+  tlr_fit <- fit(
+    tlr,
+    d_mlt_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b, c)
+  )
+  tlr_pred <- predict(tlr_fit, d_mlt_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_multinomial_spline", "cal_estimate_multinomial",
+      "cal_multi", "cal_object")
+  )
+  expect_true(all(d_mlt_test$a != tlr_pred$a))
+  expect_true(all(d_mlt_test$b != tlr_pred$b))
+  expect_true(all(d_mlt_test$c != tlr_pred$c))
+})
+
+test_that("multinomial isotonic adjust_probability_calibration usage works", {
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "isotonic")
+
+  tlr_fit <- fit(
+    tlr,
+    d_mlt_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b, c)
+  )
+  tlr_pred <- predict(tlr_fit, d_mlt_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic", "cal_multi", "cal_object")
+  )
+  expect_true(all(d_mlt_test$a != tlr_pred$a))
+  expect_true(all(d_mlt_test$b != tlr_pred$b))
+  expect_true(all(d_mlt_test$c != tlr_pred$c))
+})
+
+test_that("multinomial isotonic boot adjust_probability_calibration usage works", {
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "isotonic_boot")
+
+  set.seed(1)
+  tlr_fit <- fit(
+    tlr,
+    d_mlt_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b, c)
+  )
+  tlr_pred <- predict(tlr_fit, d_mlt_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_isotonic_boot", "cal_multi", "cal_object")
+  )
+  expect_true(all(d_mlt_test$a != tlr_pred$a))
+  expect_true(all(d_mlt_test$b != tlr_pred$b))
+  expect_true(all(d_mlt_test$c != tlr_pred$c))
+})
+
+test_that("multinomial beta adjust_probability_calibration usage works", {
+  skip_if_not_installed("betacal")
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "beta")
+
+  set.seed(1)
+  tlr_fit <- fit(
+    tlr,
+    d_mlt_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b, c)
+  )
+  tlr_pred <- predict(tlr_fit, d_mlt_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_beta", "cal_multi", "cal_object")
+  )
+  expect_true(all(d_mlt_test$a != tlr_pred$a))
+  expect_true(all(d_mlt_test$b != tlr_pred$b))
+  expect_true(all(d_mlt_test$c != tlr_pred$c))
+})
+
+test_that("multinomial no adjust_probability_calibration usage works", {
+
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "none")
+
+  tlr_fit <- fit(
+    tlr,
+    d_mlt_calibration,
+    outcome = c(y),
+    estimate = c(predicted),
+    probabilities = c(a, b, c)
+  )
+  tlr_pred <- predict(tlr_fit, d_mlt_test)
+
+  expect_s3_class(
+    tlr_fit$adjustments[[1]]$results$fit,
+    c("cal_estimate_none", "cal_multi", "cal_object")
+  )
+  expect_true(all(d_mlt_test$a == tlr_pred$a))
+  expect_true(all(d_mlt_test$b == tlr_pred$b))
+  expect_true(all(d_mlt_test$c == tlr_pred$c))
 })
 
 test_that("adjustment printing", {
@@ -101,18 +325,14 @@ test_that("adjustment printing", {
   expect_snapshot(
     tailor() |> adjust_probability_calibration(method = hardhat::tune())
   )
-
-  skip_if_not_installed("modeldata")
-  data("two_class_example", package = "modeldata")
-
   expect_snapshot(
     tailor() |>
       adjust_probability_calibration() |>
       fit(
-        two_class_example,
-        outcome = c(truth),
+        d_bin_calibration,
+        outcome = c(y),
         estimate = c(predicted),
-        probabilities = c(Class1, Class2)
+        probabilities = c(a, b)
       )
   )
 })
@@ -148,16 +368,8 @@ test_that("tunable S3 method", {
     )
   expect_equal(adj_param, exp_tunable)
 })
+
 test_that("tuning the calibration method", {
-  skip_if_not_installed("modeldata")
-  library(modeldata)
-
-  # split example data
-  set.seed(1)
-  in_rows <- sample(c(TRUE, FALSE), nrow(two_class_example), replace = TRUE)
-  d_calibration <- two_class_example[in_rows, ]
-  d_test <- two_class_example[!in_rows, ]
-
   tlr <-
     tailor() |>
     adjust_probability_calibration(method = hardhat::tune())
@@ -166,11 +378,39 @@ test_that("tuning the calibration method", {
   expect_snapshot(
     fit(
       tlr,
-      d_calibration,
-      outcome = c(truth),
+      d_bin_calibration,
+      outcome = c(y),
       estimate = c(predicted),
-      probabilities = c(Class1, Class2)
+      probabilities = c(a, b)
     ),
     error = TRUE
   )
 })
+
+
+test_that("too few data", {
+  tlr <-
+    tailor() |>
+    adjust_probability_calibration(method = "logistic")
+
+  expect_snapshot(
+    tlr_fit <- fit(
+      tlr,
+      d_bin_calibration[0,],
+      outcome = c(y),
+      estimate = c(predicted),
+      probabilities = c(a, b)
+    )
+  )
+  expect_snapshot(
+    tlr_fit <- fit(
+      tlr,
+      d_bin_calibration[1,],
+      outcome = c(y),
+      estimate = c(predicted),
+      probabilities = c(a, b)
+    )
+  )
+
+})
+


### PR DESCRIPTION
Probably has a "no calibration" calibration method. This PR enables users to choose "no calibration" and also sets `method = "none"` when there are less than two rows in the data. 

There was also some housekeeping that is included here: 

 - There were TODOs for more specific testing of calibration methods. More tests were added. 
 - A bug was fixed where multinomial data were assigned a "binary" type value and this caused `fit()` to fail. 
 - Rely less on modeldata for testing by adding a helper